### PR TITLE
Update app build and metadata for google daydream vr.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -13,13 +14,14 @@ repositories {
     jcenter()
     maven { url "http://google.bintray.com/googlevr" }
     maven { url 'https://dl.bintray.com/mobialia/maven' }
+    google()
 }
 
 apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.2"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 19
@@ -30,9 +32,9 @@ android {
 }
 
 dependencies {
-    compile 'com.google.vr:sdk-common:1.120.0'
-    compile 'com.google.vr:sdk-base:1.120.0'
+    implementation 'com.google.vr:sdk-audio:1.170.0'
+    implementation 'com.google.vr:sdk-base:1.170.0'
 
-    compile 'com.mobialia:jmini3d-core:0.9.3'
-    compile 'com.mobialia:jmini3d-android:0.9.3@aar'
+    implementation 'com.mobialia:jmini3d-core:0.9.3'
+    implementation 'com.mobialia:jmini3d-android:0.9.3@aar'
 }

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,44 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="jmini3d.demo.gvr"
-          android:versionCode="1"
-          android:versionName="1">
+          package="jmini3d.demo.gvr">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.NFC"/>
+    <!-- The GVR SDK requires API 19+ and OpenGL ES 2+. -->
+    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
+
+    <!-- Required for vibration feedback when the trigger action is performed. -->
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <!-- Required to read the paired viewer's distortion parameters. -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 
     <!-- Make accelerometer and gyroscope hard requirements for good head tracking. -->
-    <uses-feature
-        android:name="android.hardware.sensor.accelerometer"
-        android:required="true"/>
-    <uses-feature
-        android:name="android.hardware.sensor.gyroscope"
-        android:required="true"/>
+    <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true"/>
+    <uses-feature android:name="android.hardware.sensor.gyroscope" android:required="true"/>
 
-    <uses-sdk
-        android:minSdkVersion="19"
-        android:targetSdkVersion="25"/>
-    <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true"/>
+    <!-- Indicates use of Android's VR-mode, available only on Android N+. -->
+    <uses-feature android:name="android.software.vr.mode" android:required="false"/>
+    <!-- Indicates use of VR features that are available only on Daydream-ready devices. -->
+    <uses-feature android:name="android.hardware.vr.high_performance" android:required="false"/>
 
     <application
         android:allowBackup="true"
         android:supportsRtl="true"
+        android:theme="@style/VrActivityTheme"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name">
         <activity
             android:name=".VRActivity"
             android:label="@string/app_name"
             android:screenOrientation="landscape"
-            android:configChanges="orientation|keyboardHidden|screenSize">
+            android:configChanges="orientation|keyboardHidden|screenSize|uiMode|navigation|density"
+            android:enableVrMode="@string/gvr_vr_mode_component"
+            android:resizeableActivity="false">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="com.google.intent.category.CARDBOARD" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
-                <category android:name="com.google.intent.category.CARDBOARD"/>
+                <!-- The DAYDREAM category should only be declared by Activities that are Daydream
+                     compatible. Daydream compatible apps should typically use the Daydream
+                     controller APIs directly, however in this sample app we instead rely on
+                     Cardboard trigger emulation. -->
+                <category android:name="com.google.intent.category.DAYDREAM" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
Small build and metadata changes to run the demo directly on daydream VR without having to switch back to cardboard.  May or may not be something you wish to take.